### PR TITLE
Speculative fix for outbound messages going out of order

### DIFF
--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -152,6 +152,8 @@ private class MessageSendingQueue {
                         // Retry sending after 0.5s
                         self?.sendNextMessage(afterDelay: 0.5)
                     } else {
+                        // The message was marked as failed so it's safe
+                        // to remove the request and carry on.
                         self?.removeRequestAndContinue(request)
                     }
                 }

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -136,15 +136,25 @@ private class MessageSendingQueue {
     }
 
     /// Gets the oldest message from the queue and tries to send it.
-    private func sendNextMessage() {
-        dispatchQueue.async { [weak self] in
+    private func sendNextMessage(afterDelay delay: TimeInterval = 0) {
+        dispatchQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
             // Sort the messages and send the oldest one
             // If this proves to be a bottleneck in the future, we might
             // switch to using a custom `OrderedSet`
             guard let request = self?.requests.sorted(by: { $0.createdLocallyAt < $1.createdLocallyAt }).first else { return }
 
-            self?.messageRepository.sendMessage(with: request.messageId) { _ in
-                self?.removeRequestAndContinue(request)
+            self?.messageRepository.sendMessage(with: request.messageId) { result in
+                switch result {
+                case .success(_):
+                    self?.removeRequestAndContinue(request)
+                case let .failure(error):
+                    if error == .failedToSendMessageWithStatusUpdateError {
+                        // Retry sending after 1s
+                        self?.sendNextMessage(afterDelay: 1)
+                    } else {
+                        self?.removeRequestAndContinue(request)
+                    }
+                }
             }
         }
     }

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -149,8 +149,8 @@ private class MessageSendingQueue {
                     self?.removeRequestAndContinue(request)
                 case let .failure(error):
                     if error == .failedToSendMessageWithStatusUpdateError {
-                        // Retry sending after 1s
-                        self?.sendNextMessage(afterDelay: 1)
+                        // Retry sending after 0.5s
+                        self?.sendNextMessage(afterDelay: 0.5)
                     } else {
                         self?.removeRequestAndContinue(request)
                     }


### PR DESCRIPTION
### Background

This is an attempt to fix the issue where outbound messages are jumbled up which we've been noticed multiple instances.
I have a speculation on a particular cause which I filed here - https://github.com/GetStream/stream-chat-swift/issues/2693

I was abled to reproduce the issue in a simulator environment where I tweaked code to force the error. However, I don't have concrete evidence that the error actually happened and thus caused the issue.

### Approach

Previously, when [we failed to mark a message to `.sending`](https://github.com/reclipapp/stream-chat-swift/blob/74bf3f348600762e38f66a78582252eb7ce9a043/Sources/StreamChat/Repositories/MessageRepository.swift#L57-L63), the failed message was removed the send request queue without being marked as `.sendingFailed`. The message would look as if it's successfully sent. Also, subsequent messages could be sent w/o error after that. On the remote side, the failed message wouldn't be received. After this, if user restart the app, the message which was silently failed will be retried. This is how the message order go wrong.

**The fix**

I attempt the fix in two steps:
1. Try to mark `.sendingFailed`. (There was an obvious bug)
2. There's a good chance the above could also fail given marking it to `.sending` failed just before. In this case, we would retry sending with 0.5sec interval until it succeed. This could be risky because if this keeps failing we won't be able to send any further messages. However, in all reports, I noticed the message was eventually sent and also subsequent messages were successfully sent. After all, we need to keep the order of the messages, so I should wait until the first message succeed.

### Test strategy

NB:
- Both tested with stimulated error.
- Testing were done across two sessions. So, wait till the end of video. Both of them.

| before | after |
| ------ | ----- |
| <video src="https://github.com/reclipapp/stream-chat-swift/assets/128518318/1e8238e7-f722-4c1c-808f-39894cd85613" /> | <video src="https://github.com/reclipapp/stream-chat-swift/assets/128518318/5505293e-e3c4-4723-9ff8-7d4ec3c62d11" /> |