### PR TITLE
Speculative fix for laggy chat UX

### DIFF
--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -264,9 +264,6 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
     /// - Throws: An error if the provided fetch request fails.
     func startObserving() throws {
         _items.computeValue = { [weak self] in
-            if Thread.isMainThread {
-                print("too bad")
-            }
             guard let frc = self?.frc,
                   let itemCreator = self?.itemCreator,
                   let context = self?.context else { return [] }

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -194,7 +194,7 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
                             
                             // make `items` up-to-date before `onChange`
                             self._items.update(items)
-                            self.onChange?(self.mainThreadChanges)
+                            self.onChange?(changes)
                         }
                     }
                 } else {

--- a/Sources/StreamChat/Utils/Cached.swift
+++ b/Sources/StreamChat/Utils/Cached.swift
@@ -48,8 +48,8 @@ class Cached<T> {
         _cached = nil
     }
     
-    /// Resets the current cached value directly to a new value.
-    func reset(_ newValue: T) {
+    /// Updates the current cached value directly to a new value.
+    func update(_ newValue: T) {
         __cached.mutate { value in
             value = newValue
         }

--- a/Sources/StreamChat/Utils/Cached.swift
+++ b/Sources/StreamChat/Utils/Cached.swift
@@ -47,4 +47,11 @@ class Cached<T> {
     func reset() {
         _cached = nil
     }
+    
+    /// Resets the current cached value directly to a new value.
+    func reset(_ newValue: T) {
+        __cached.mutate { value in
+            value = newValue
+        }
+    }
 }


### PR DESCRIPTION
### Background

I've noticed that `NSManagedObjectContext.performAndWait()` is called in the main thread, a lot.
This is against the very basic GUI programming principle: One must not do any blocking I/O operation in the main thread.

While I'm not 100% sure if this is actually causing the laggy chat issue or not, calling `performAndWait()` in the main thread is apparently wrong and will eventually cause trouble in one way or another as the database grows. That's why there's an alternative of `performAndWait()` for the main thread: `perform()`.

### Approach

We can't simply replace `performAndWait()` with `perform()`, because it requires the call-site of `performAndWait()` to be converted to `async`. This has a snowball effect, i.e. call-sites of the call-site need to be changed to `async` and so on. Thus it will eventually results avalanche of changes.
The proper fix of this issue would be fundamental change of the whole library which isn't an option for us now.

I don't have many options here but there's one particular bottle neck I noticed in `ListDatabaseObserver` which is used to observe messages changes in a channel. So, I decided to address that a bit hacky/patchy way. -- See the details in the file diff.

To be honest, I'm not getting my hopes high for this. There are just too many `performAndWait()` calls in the main thread. This PR only addresses `performAndWait()` in `ListDatabaseObserver` triggered by `onChange()`. But there are many other cases where `performAndWait()` is called, especially when foregrounding app and entering chat.

If I got luck this PR _might_ address the following scenarios:
- After user enters a chat and scrolling through threads. i.e. the chat threads already displayed once.
- User sends messages in chat.

However, this won't address the following:
- Entering a chat
- Laggy UX in channel list, or everywhere other than chat thread.

### Changes

### Test strategy

As I'm not a heavy chat user, I don't really experience the laggy chat issue myself much, so I couldn't really check if this makes any changes.
Instead, I verified there's no regression in basic chat message exchange between two users.